### PR TITLE
index.js aliases

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+jquery.js


### PR DESCRIPTION
Kinda late to the party here. I should have brought this up way earlier.

It would be nice if we had an `index.js` aliases so if your package managed supported the shorthand, you could just `require('jquery')` instead of `require('jquery/jquery')`.

It'd be sort of nice to assume `main` meant the same thing as `index.js`, but its weird that `component.json`'s `main` value can accept an array.

Maybe this is a discussion for bower-core? Also I dunno if its way to late or even a good idea to repush those tags.

/cc @paulirish @fat @maccman
