### PR TITLE
Add Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "components/jquery",
+    "description": "jQuery JavaScript Library",
+    "type": "component",
+    "homepage": "http://jquery.com",
+    "license": "MIT",
+    "support": {
+        "irc": "irc://irc.freenode.org/jquery",
+        "issues": "http://bugs.jquery.com",
+        "forum": "http://forum.jquery.com",
+        "wiki": "http://docs.jquery.com/",
+        "source": "https://github.com/jquery/jquery"
+    },
+    "authors": [
+        {
+            "name": "John Resig",
+            "email": "jeresig@gmail.com"
+        }
+    ],
+    "extra": {
+        "js": "jquery.js"
+    }
+}


### PR DESCRIPTION
[Composer](http://getcomposer.org/) is a package manager for PHP. Its [statistics](https://packagist.org/statistics) prove how its adoption is steadily growing. Having a composer.json in the shim repository would mean that PHP applications could easily consume the package.

In PHP applications, they would just have to define the following in their `composer.json`:

```
{
    "require": {
        "components/jquery": "1.8.*"
    }
}
```

Running `composer install` will then download the latest jQuery 1.8 package.

The version of the package is determined from the tag it's built off of.
