### PR TITLE
Use Component Installer to install jQuery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
             "email": "jeresig@gmail.com"
         }
     ],
+    "require": {
+        "robloach/component-installer": "*"
+    },
     "extra": {
         "js": "jquery.js"
     }


### PR DESCRIPTION
Make use of Component Install to allow installing jQuery via Composer:
http://github.com/robloach/component-installer

This will install jQuery to `component/components-jquery` to mimic how Component installs components.
