### PR TITLE
Use minified main

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,5 +3,5 @@
   "version": "2.0.3",
   "description": "jQuery component",
   "keywords": ["jquery"],
-  "main": "./jquery.js"
+  "main": "./jquery.min.js"
 }


### PR DESCRIPTION
By default, this repo can use the minified main since it comes with a source map.
